### PR TITLE
fix error for pulling module which is not installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## unreleased
+* Improvement: Better error handling for pos-cli modules pull
+
 ## 4.24.1
 * Chore: Updated dependencies
 

--- a/bin/pos-cli-modules-pull.js
+++ b/bin/pos-cli-modules-pull.js
@@ -9,7 +9,6 @@ const fetchAuthData = require('../lib/settings').fetchSettings;
 const downloadFile = require('../lib/downloadFile');
 const waitForStatus = require('../lib/data/waitForStatus');
 const spinner = ora({ text: 'Exporting', stream: process.stdout, spinner: 'bouncingBar' });
-const { unzip } = require('../lib/unzip');
 
 program
   .name('pos-cli modules pull')
@@ -26,12 +25,12 @@ program
       .then(exportTask => downloadFile(exportTask.zip_file.url, filename))
       .then(() => spinner.succeed('Downloading files'))
       .catch({ statusCode: 404 }, () => {
-        spinner.fail('Export failed');
-        logger.Error('[404] Module not found');
+        spinner.fail(`Pulling ${module} failed.`);
+        logger.Error('[404] Zip file with module files not found');
       })
       .catch(e => {
-        spinner.fail('Export failed');
-        logger.Error(e.message);
+        spinner.fail(`Pulling ${module} failed.`);
+        logger.Error(e.message || e.error.error || e.error);
       });
   });
 


### PR DESCRIPTION
Before:

![image](https://github.com/Platform-OS/pos-cli/assets/30107/e8dd0e7d-f2d1-46ff-b899-8456e50c6ba0)

After:

![image](https://github.com/Platform-OS/pos-cli/assets/30107/05027167-447e-4aa1-a91d-1159db426937)
