### PR TITLE
improve finding the right template-values.json when pushing new module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Improvement: Always store generated `asset_manifest.json` in tmp/ for debugging purposes
 * Chore: Removed unused `readdirp` node package
 * Chore: Removed `valid-url` node package and replaced it with native Node validation
+* Improvement: Better handling of template-values.json during pos-cli modules push
 
 ## 5.1.4
 * Chore: Remove `pluralize` node package

--- a/bin/pos-cli-modules-push.js
+++ b/bin/pos-cli-modules-push.js
@@ -12,6 +12,7 @@ program
   .name('pos-cli modules push')
   .requiredOption('--email <email>', 'Partner Portal account email. Example: foo@example.com')
   .option('--path <path>', 'module root directory, default is current directory')
+  .option('--name <name>', 'name of the module you would like to publish')
   .action(async (params) => {
     try {
       if (params.path) process.chdir(params.path);

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -16,30 +16,48 @@ let moduleId;
 const archiveFileName = 'release.zip';
 const archivePath = `./tmp/${archiveFileName}`;
 const moduleConfigFileName = 'template-values.json';
+let filePath = moduleConfigFileName;
 
-const moduleConfig = async () => {
-  const filePath = await moduleConfigFilePath();
-  return files.readJSON(filePath || moduleConfigFileName, { throwDoesNotExistError: true, exit: true });
+const moduleConfig = async (moduleName) => {
+  if(!fs.existsSync(filePath)) {
+    const moduleConfigPath = await moduleConfigFilePath(moduleName);
+    if(moduleConfigPath) {
+      filePath = moduleConfigPath
+    } else if(moduleName) {
+      filePath = `modules/${moduleName}/${moduleConfigFileName}`
+    }
+  }
+  return files.readJSON(filePath, { throwDoesNotExistError: true, exit: true });
 };
 
-const moduleConfigFilePath = async () => {
-  const configFiles = await glob([`modules/*/${moduleConfigFileName}`, moduleConfigFileName]);
+const moduleConfigFilePath = async (moduleName="*") => {
+  const configFiles = await glob([`modules/${moduleName}/${moduleConfigFileName}`, moduleConfigFileName]);
+  if(configFiles.length > 1) {
+    throw new Error(`There is more than one modules/*/template-values.json, please use --name parameter or create template-values.json in the root of the project.`);
+  }
   return configFiles[0];
 }
 
 const createArchive = async (moduleName) => {
-  return new Promise(async (resolve, reject) => {
-    const releaseArchive = prepareArchive(archivePath, resolve, true);
-    if (fs.existsSync(moduleConfigFileName)){
-      releaseArchive.glob(['**/**', moduleConfigFileName], { ignore: ['**/node_modules/**', '**/tmp/**'] }, { prefix: moduleName });
-    } else {
-      releaseArchive.glob(['**/**', moduleConfigFileName], { ignore: ['*node_modules', '**/tmp/**'], cwd: `${process.cwd()}/modules/${moduleName}` }, { prefix: moduleName });
-      const filePath = await moduleConfigFilePath();
-      releaseArchive.file(filePath, { name: moduleConfigFileName, prefix: moduleName });
-    }
-    await releaseArchive.finalize();
-  });
-};
+  try {
+    return new Promise(async (resolve, reject) => {
+      const releaseArchive = prepareArchive(archivePath, resolve, true);
+      if (fs.existsSync(moduleConfigFileName) && !fs.existsSync(`modules/`)){
+        logger.Warn(`Cannot find modules/${moduleName}, creating archive with the current directory.`);
+        releaseArchive.glob(['**/**', moduleConfigFileName], { ignore: ['**/node_modules/**', '**/tmp/**', 'app/'] }, { prefix: moduleName });
+      } else if(fs.existsSync(`modules/${moduleName}/`)) {
+        logger.Info(`Creating archive for modules/${moduleName}`);
+        releaseArchive.glob(['**/**', moduleConfigFileName], { ignore: ['*node_modules', '**/tmp/**'], cwd: `${process.cwd()}/modules/${moduleName}` }, { prefix: moduleName });
+        releaseArchive.file(filePath, { name: moduleConfigFileName, prefix: moduleName });
+      } else {
+        reject(new Error(`There is no directory modules/${moduleName} - please double check the machine_name property in ${filePath}`))
+      }
+      await releaseArchive.finalize();
+    });
+  } catch(e) {
+    throw e;
+  }
+}
 
 const uploadArchive = async (token) => {
   const data = await presignUrl(token, moduleId, archiveFileName);
@@ -99,7 +117,7 @@ const portalAuthToken = async (email, password) => {
 
 const publishVersion = async (params) => {
   try {
-    const config = await moduleConfig();
+    const config = await moduleConfig(params.name);
     const moduleName = config['machine_name'];
     const moduleVersionName = config['version'];
     const numberOfFiles = await createArchive(moduleName);

--- a/test/fixtures/modules/multiple_modules/modules/bar/template-values.json
+++ b/test/fixtures/modules/multiple_modules/modules/bar/template-values.json
@@ -1,0 +1,7 @@
+{
+  "name": "Bar",
+  "machine_name": "bar",
+  "type": "module",
+  "version": "0.0.1",
+  "dependencies": {}
+}

--- a/test/fixtures/modules/multiple_modules/modules/foo/template-values.json
+++ b/test/fixtures/modules/multiple_modules/modules/foo/template-values.json
@@ -1,0 +1,7 @@
+{
+  "name": "Foo",
+  "machine_name": "foo",
+  "type": "module",
+  "version": "0.0.1",
+  "dependencies": {}
+}

--- a/test/fixtures/modules/template_values_in_root_first/modules/foo/template-values.json
+++ b/test/fixtures/modules/template_values_in_root_first/modules/foo/template-values.json
@@ -1,0 +1,7 @@
+{
+  "name": "Foo",
+  "machine_name": "foo",
+  "type": "module",
+  "version": "0.0.1",
+  "dependencies": {}
+}

--- a/test/fixtures/modules/template_values_in_root_first/template-values.json
+++ b/test/fixtures/modules/template_values_in_root_first/template-values.json
@@ -1,0 +1,8 @@
+{
+  "name": "Foo",
+  "machine_name": "bar",
+  "type": "module",
+  "version": "0.0.1",
+  "dependencies": {}
+}
+

--- a/test/modules-push.test.js
+++ b/test/modules-push.test.js
@@ -17,6 +17,21 @@ describe('Server errors', () => {
     expect(stderr).toMatch("File doesn't exist: template-values.json");
   });
 
+  test('Multiple modules with template-values.json', async () => {
+    const { stdout, stderr } = await run('multiple_modules', '--email pos-cli-ci@platformos.com');
+    expect(stderr).toMatch("There is more than one modules/*/template-values.json, please use --name parameter or create template-values.json in the root of the project.");
+  });
+
+  test('Multiple modules with template-values.json and invalid name', async () => {
+    const { stdout, stderr } = await run('multiple_modules', '--email pos-cli-ci@platformos.com --name missing');
+    expect(stderr).toMatch("File doesn't exist: modules/missing/template-values.json");
+  });
+
+  test('Error in root template-values.json', async () => {
+    const { stdout, stderr } = await run('template_values_in_root_first', '--email pos-cli-ci@platformos.com --name foo');
+    expect(stderr).toMatch("There is no directory modules/bar");
+  });
+
   test.skip('now we include template-values.json in release', async () => {
     const { stdout, stderr } = await run('no_files', '--email pos-cli-ci@platformos.com');
     expect(stderr).toMatch("There are no files in module release");


### PR DESCRIPTION
Before this PR, when `pos-cli modules push --email <email>` is invoked, the code works as follows:

* Try to find the first `template-values.json` file which matches `modules/*/template-values.json`. (this is problematic if there are multiple template-values.json, which is the case if you download dependencies via pos-cli modules download, which also downloads template-values.json)
  * If it's there, take the `machine_name` attribute from the file and create Zip Archive based on `modules/<machine_name>` (this is problematic if there's a mismatch between the directory name and the value inside template-values.json`)
  * If it's not, find the `./template-values.json` from the current directory
    * If it's there, archive the current directory (for backwards compatibility, some of the old modules have `public` and `private` directories directly in the root)
    * If it's not there, throw an error that template-values.json does not exists

This PR aim to improve the logic by:
* Try to find `template-values.json` in the root of the project first. If it exists, and `modules/` exists (meaning, it's not the old structure of the module repository) - use it. 
* Introduce new `--name` option to specify which module you want to publish
* Add additional error handling to avoid publishing wrong module:
  * Throw error if there is more then one modules/*/template-values.json - error message asks to specify the module using the new `--name` option or create template-values.json in the root
  * Throw error if `modules/<machine_name>` does not exist, suggesting checking <path to template-values.json used>