### PR TITLE
Fix for JSON contents not accessible for data import

### DIFF
--- a/bin/pos-cli-data-import.js
+++ b/bin/pos-cli-data-import.js
@@ -26,7 +26,6 @@ const initializeEsmModules = async () => {
 }
   
 let gateway;
-const tmpFileName = './tmp/data-imported.json';
 
 const logInvalidFile = (filename) => {
   return logger.Error(
@@ -61,9 +60,7 @@ const dataImport = async (filename, rawIds, isZipFile) => {
     const data = fs.readFileSync(filename, 'utf8');
     if (!isValidJSON(data)) return logInvalidFile(filename);
     const transformedData = await transform(JSON.parse(data));
-    shell.mkdir('-p', './tmp');
-    fs.writeFileSync(tmpFileName, JSON.stringify(transformedData));
-    formData = { 'import[data]': fs.createReadStream(tmpFileName) };
+    formData = { 'import': { 'data': transformedData } };
   }
 
   formData['raw_ids'] = rawIds;

--- a/test/data.test.js
+++ b/test/data.test.js
@@ -19,7 +19,10 @@ describe('Data clean', () => {
 describe('Data clean real', () => {
   test('shows message when wrong confirmation passed inline', async () => {
     const {code, stderr, stdout} = await exec(`echo "CLEAN DATA" | ${cliPath} data clean`, { env });
-    expect(stderr).toMatch('NotFound')
+    expect(stderr).toMatch('WARNING!!! You are going to REMOVE your data from instance: http://example.com')
+    expect(stderr).toMatch('There is no coming back.')
+    expect(stderr).toMatch('"statusCode": 405')
+    expect(stderr).toMatch('"pathname": "/api/app_builder/data_clean"')
     expect(stderr).toMatch(env.MPKIT_URL)
   });
 });


### PR DESCRIPTION
This is a fix for:

```
[21:29:16] 406 - {"errors":["param is missing or the value is empty: data"]}
```

Even if we had gotten the backend to look at the actual data, it would have been a JSON representation of a stream.

Thanks!