### PR TITLE
Fix/mcp server exit crash

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,9 @@ pos-cli/
 │   ├── pos-cli-lsp.js           # Language Server Protocol server
 │   ├── pos-cli-mcp.js           # MCP server entry point
 │   ├── pos-cli-mcp-config.js    # Display MCP tool configuration
+│   ├── pos-cli-ai.js            # AI tools command group
+│   ├── pos-cli-ai-init.js       # Wizard: register MCP servers in AI tool config
+│   ├── pos-cli-supervisor.js    # platformos-mcp-supervisor wrapper (validate_code MCP server)
 │   └── pos-cli-fetch-logs.js    # Fetch logs as NDJSON (for scripting/MCP)
 ├── lib/              # Core business logic
 │   ├── proxy.js                 # Gateway class - main API client
@@ -70,6 +73,7 @@ pos-cli/
 │   ├── archive.js               # Deployment archive creation
 │   ├── push.js                  # Archive upload
 │   ├── check.js                 # Liquid/JSON linter (platformos-check)
+│   ├── ai.js                    # AI tool MCP config wizard (pos-cli ai init)
 │   ├── templates.js             # Mustache template processing
 │   ├── modules.js               # Module lifecycle management
 │   ├── deploy/                  # Deployment strategies

--- a/README.md
+++ b/README.md
@@ -874,6 +874,25 @@ Example:
 
 pos-cli includes a built-in [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that exposes platformOS operations as tools for AI clients such as Claude, Cursor, and other MCP-compatible assistants. This lets AI agents deploy code, run GraphQL queries, manage data, execute migrations, and more — all directly against your platformOS instances.
 
+#### Quick setup: pos-cli ai init
+
+The fastest way to connect your AI tool is the one-step wizard:
+
+    pos-cli ai init
+
+It asks which AI tool you use and registers both platformOS MCP servers — `platformos` (the pos-cli tools listed below) and `platformos-supervisor` (Liquid/GraphQL/YAML code validation via `validate_code`) — in that tool's project-scoped configuration:
+
+| Tool        | Configuration file  | Key          |
+| ----------- | ------------------- | ------------ |
+| Claude Code | `.mcp.json`         | `mcpServers` |
+| Cursor      | `.cursor/mcp.json`  | `mcpServers` |
+| VS Code     | `.vscode/mcp.json`  | `servers`    |
+| Other       | prints the JSON snippet for manual setup | — |
+
+Run it from your project root. Existing configuration files are merged, never overwritten — other MCP servers and unrelated settings are preserved, and re-running the command is a no-op. To skip the prompt (e.g. in scripts), pass the tool directly:
+
+    pos-cli ai init --tool claude
+
 #### Starting the MCP Server
 
     pos-cli mcp
@@ -882,17 +901,30 @@ This starts both a **stdio transport** (for editor/AI integrations) and an **HTT
 
 #### Configuring Claude Code
 
-Add the following to your Claude Code settings (`.claude/settings.json`) to use pos-cli as an MCP server:
+Run `pos-cli ai init --tool claude` to generate this automatically, or add the following to a `.mcp.json` file at your project root:
 
 ```json
 {
   "mcpServers": {
     "platformos": {
       "command": "pos-cli-mcp"
+    },
+    "platformos-supervisor": {
+      "command": "pos-cli-supervisor"
     }
   }
 }
 ```
+
+Both commands are installed globally with pos-cli (`npm install -g @platformos/pos-cli`).
+
+#### Supervisor MCP server (pos-cli-supervisor)
+
+    pos-cli-supervisor [--project <dir>]
+
+Starts the [platformOS MCP supervisor](https://github.com/Platform-OS/platformos-tools/tree/master/packages/platformos-mcp-supervisor) — a stdio-only MCP server exposing a single `validate_code` tool that lets AI agents validate platformOS Liquid, GraphQL, and YAML files *before* writing them. It returns structured errors, warnings, proposed fixes, and a `must_fix_before_write` gate.
+
+The project directory is resolved from `--project`, then the `POS_SUPERVISOR_PROJECT_DIR` environment variable, then the current working directory (which is what MCP clients use when launched via `pos-cli ai init`). All logging goes to stderr — stdout is reserved for the MCP protocol.
 
 #### Available Tools
 

--- a/bin/pos-cli-ai-init.js
+++ b/bin/pos-cli-ai-init.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+import { Option } from 'commander';
+import { program } from '../lib/program.js';
+import { init } from '../lib/ai.js';
+
+program
+  .name('pos-cli ai init')
+  .description('register platformOS MCP servers (platformos, platformos-supervisor) in your AI tool configuration')
+  .addOption(
+    new Option('--tool <tool>', 'skip the interactive prompt and configure the given tool').choices([
+      'claude',
+      'cursor',
+      'vscode',
+      'other'
+    ])
+  )
+  .action(async (options) => {
+    await init({ tool: options.tool });
+  });
+
+program.parse(process.argv);

--- a/bin/pos-cli-ai.js
+++ b/bin/pos-cli-ai.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import { program } from '../lib/program.js';
+
+program
+  .name('pos-cli ai')
+  .command('init', 'register platformOS MCP servers in your AI tool configuration')
+  .parse(process.argv);

--- a/bin/pos-cli-supervisor.js
+++ b/bin/pos-cli-supervisor.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+// stdout is reserved for MCP JSON-RPC - never write to it in this file.
+import path from 'path';
+import logger from '../lib/logger.js';
+
+const loadSupervisor = async () => {
+  try {
+    return await import('@platformos/platformos-mcp-supervisor');
+  } catch {
+    await logger.Error(
+      'The @platformos/platformos-mcp-supervisor package is not installed.\n' +
+        'Install it with: npm install -g @platformos/pos-cli',
+      { notify: false }
+    );
+  }
+};
+
+// same precedence as the upstream bin: --project > POS_SUPERVISOR_PROJECT_DIR > cwd
+const args = process.argv.slice(2);
+const projectFlagIndex = args.indexOf('--project');
+const projectDir = path.resolve(
+  (projectFlagIndex !== -1 && args[projectFlagIndex + 1]) ||
+    args.find((arg) => arg.startsWith('--project='))?.slice('--project='.length) ||
+    process.env.POS_SUPERVISOR_PROJECT_DIR ||
+    process.cwd()
+);
+
+const supervisor = await loadSupervisor();
+const startServer = supervisor.startServer ?? supervisor.default?.startServer;
+await startServer({ projectDir });

--- a/bin/pos-cli.js
+++ b/bin/pos-cli.js
@@ -17,6 +17,7 @@ program.showHelpAfterError();
 program
   .name('pos-cli')
   .version(version, '-v, --version')
+  .command('ai', 'configure AI tools (register platformOS MCP servers)')
   .command('archive', 'create an archive only (no deployment)')
   .command('audit', 'check your code for deprecations, recommendations, errors')
   .command('check', 'check Liquid code quality with platformos-check linter')

--- a/lib/ai.js
+++ b/lib/ai.js
@@ -1,0 +1,83 @@
+import fs from 'fs';
+import path from 'path';
+import logger from './logger.js';
+
+const SERVERS = {
+  platformos: { command: 'pos-cli-mcp' },
+  'platformos-supervisor': { command: 'pos-cli-supervisor' }
+};
+
+const TOOLS = {
+  claude: { label: 'Claude Code', file: '.mcp.json', key: 'mcpServers', entry: (server) => ({ ...server }) },
+  cursor: { label: 'Cursor', file: '.cursor/mcp.json', key: 'mcpServers', entry: (server) => ({ ...server }) },
+  vscode: { label: 'VS Code', file: '.vscode/mcp.json', key: 'servers', entry: (server) => ({ type: 'stdio', ...server }) },
+  other: { label: 'Other' }
+};
+
+const promptForTool = async () => {
+  const { select } = await import('@inquirer/prompts');
+  try {
+    return await select({
+      message: 'Which AI tool do you use?',
+      choices: Object.entries(TOOLS).map(([value, tool]) => ({ name: tool.label, value }))
+    });
+  } catch (error) {
+    if (error.name === 'ExitPromptError') {
+      process.exit(0);
+    }
+    throw error;
+  }
+};
+
+const printManualSnippet = async () => {
+  await logger.Info('Add these stdio MCP servers to your AI tool configuration:', { hideTimestamp: true });
+  await logger.Log(JSON.stringify({ mcpServers: SERVERS }, null, 2));
+};
+
+const configureTool = async (toolId, rootPath) => {
+  const tool = TOOLS[toolId];
+  const configPath = path.join(rootPath, ...tool.file.split('/'));
+
+  let config = {};
+  if (fs.existsSync(configPath)) {
+    try {
+      config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    } catch (error) {
+      return logger.Error(
+        `${tool.file} exists but is not valid JSON: ${error.message}\n` +
+          'Fix or remove the file and run pos-cli ai init again.'
+      );
+    }
+  }
+
+  const servers = (config[tool.key] = config[tool.key] || {});
+  const added = [];
+  const updated = [];
+
+  for (const [name, server] of Object.entries(SERVERS)) {
+    const desired = tool.entry(server);
+    if (JSON.stringify(servers[name]) === JSON.stringify(desired)) continue;
+    (servers[name] ? updated : added).push(name);
+    servers[name] = desired;
+  }
+
+  if (added.length === 0 && updated.length === 0) {
+    return logger.Success(`${tool.label} is already configured in ${tool.file} - nothing to do.`);
+  }
+
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
+
+  if (updated.length > 0) {
+    await logger.Info(`Updated existing entries in ${tool.file}: ${updated.join(', ')}`);
+  }
+  await logger.Success(`Registered MCP servers (${Object.keys(SERVERS).join(', ')}) for ${tool.label} in ${tool.file}`);
+};
+
+const init = async ({ tool, rootPath = process.cwd() } = {}) => {
+  const toolId = tool || (await promptForTool());
+  if (toolId === 'other') return printManualSnippet();
+  return configureTool(toolId, rootPath);
+};
+
+export { init, SERVERS, TOOLS };

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -11,6 +11,17 @@ const isSimple = !!process.env.NO_COLOR || !!process.env.CI;
 let instance = null;
 let instancePromise = null;
 
+// Server mode: when a long-lived host (the MCP server) loads this CLI code
+// in-process, a fatal logger.Error must NOT process.exit — that would tear
+// down the whole server and every tool it serves. In server mode Error throws
+// instead, so the host's per-request try/catch turns it into a caught error.
+// Sourced from an env var so it survives across duplicate module instances.
+const isServerMode = () => process.env.POS_CLI_SERVER_MODE === '1';
+const setServerMode = (on) => {
+  if (on) process.env.POS_CLI_SERVER_MODE = '1';
+  else delete process.env.POS_CLI_SERVER_MODE;
+};
+
 const loadLogger = async () => {
   if (instance) return instance;
   if (instancePromise) return instancePromise;
@@ -74,6 +85,11 @@ const logger = {
     await callInstance('Error', [msg]).catch(() => {});
 
     if (options.exit) {
+      // In server mode, throw so the host can catch it; exiting would kill
+      // the whole server. Standalone CLI keeps the process.exit contract.
+      if (isServerMode()) {
+        throw new Error(msg);
+      }
       process.exit(1);
     }
 
@@ -97,3 +113,4 @@ const logger = {
 };
 
 export default logger;
+export { setServerMode, isServerMode };

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -50,9 +50,15 @@ const loadSettingsFileForModule = module => {
   return base;
 };
 
-const fetchSettings = async (environment) => {
+const fetchSettings = async (environment, { exit = true } = {}) => {
   const settings = settingsFromEnv() || settingsFromDotPos(environment);
   if (settings) return settings;
+
+  // Long-lived callers (e.g. the MCP server) pass { exit: false } so an
+  // unresolved environment is a recoverable miss they can turn into a caught
+  // error — never a process.exit that would tear down the whole server. CLI
+  // callers keep the default exit:true for the usual "print message and die".
+  if (!exit) return null;
 
   if (environment) {
     await logger.Error(`No settings for ${environment} environment, please see pos-cli env add`);

--- a/mcp-min/__tests__/auth.env-resolve.test.js
+++ b/mcp-min/__tests__/auth.env-resolve.test.js
@@ -1,0 +1,75 @@
+import fs from 'fs';
+import path from 'path';
+import { vi, describe, test, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+
+import { fetchSettings } from '../../lib/settings.js';
+import { resolveAuth } from '../auth.js';
+
+// Regression guard for the "env not found kills the MCP server" crash.
+//
+// The server resolves auth via resolveAuth -> fetchSettings. Historically
+// fetchSettings did process.exit(1) on an unknown environment, which killed
+// the whole in-process server before auth.js could throw its catchable error.
+// The fix: fetchSettings(env, { exit:false }) returns null so resolveAuth can
+// throw a normal Error the per-request handler turns into an MCP error.
+const CONFIG_FILE = path.resolve(`.pos.test-auth-resolve`);
+
+describe('env resolution never exits the process', () => {
+  beforeAll(() => {
+    fs.writeFileSync(
+      CONFIG_FILE,
+      JSON.stringify({ staging: { url: 'https://staging.example.com', email: 'e@x', token: 't' } }, null, 2)
+    );
+    process.env.CONFIG_FILE_PATH = CONFIG_FILE;
+  });
+
+  afterAll(() => {
+    if (fs.existsSync(CONFIG_FILE)) fs.unlinkSync(CONFIG_FILE);
+    delete process.env.CONFIG_FILE_PATH;
+  });
+
+  beforeEach(() => {
+    // MPKIT_* would short-circuit settingsFromEnv(); keep resolution on .pos.
+    delete process.env.MPKIT_URL;
+    delete process.env.MPKIT_EMAIL;
+    delete process.env.MPKIT_TOKEN;
+  });
+
+  test('fetchSettings(unknown, {exit:false}) returns null instead of exiting', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit must not be called with {exit:false}');
+    });
+
+    const found = await fetchSettings('does-not-exist', { exit: false });
+    expect(found).toBeNull();
+    expect(exitSpy).not.toHaveBeenCalled();
+
+    exitSpy.mockRestore();
+  });
+
+  test('fetchSettings(known, {exit:false}) returns the settings', async () => {
+    const found = await fetchSettings('staging', { exit: false });
+    expect(found).toMatchObject({ url: 'https://staging.example.com' });
+  });
+
+  test('resolveAuth throws a catchable error for an unknown env (no exit)', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit must not be called from resolveAuth');
+    });
+
+    await expect(resolveAuth({ env: 'ps' })).rejects.toThrow(/Environment 'ps' not found/);
+    expect(exitSpy).not.toHaveBeenCalled();
+
+    exitSpy.mockRestore();
+  });
+
+  test('resolveAuth resolves a known env from .pos', async () => {
+    const auth = await resolveAuth({ env: 'staging' });
+    expect(auth).toMatchObject({ url: 'https://staging.example.com', source: '.pos(staging)' });
+  });
+
+  test('explicit url/email/token params bypass .pos resolution', async () => {
+    const auth = await resolveAuth({ url: 'https://direct', email: 'e@x', token: 'tok' });
+    expect(auth).toMatchObject({ url: 'https://direct', source: 'params' });
+  });
+});

--- a/mcp-min/__tests__/logger.server-mode.test.js
+++ b/mcp-min/__tests__/logger.server-mode.test.js
@@ -1,0 +1,79 @@
+import { vi, describe, test, expect, beforeAll, afterEach } from 'vitest';
+
+// The global test setup (test/vitest-setup.js) mocks #lib/logger.js to silence
+// output. This file must exercise the REAL logger to verify server-mode
+// behavior, so pull the actual implementation via importActual.
+let logger;
+let setServerMode;
+let isServerMode;
+
+beforeAll(async () => {
+  const actual = await vi.importActual('../../lib/logger.js');
+  logger = actual.default;
+  setServerMode = actual.setServerMode;
+  isServerMode = actual.isServerMode;
+});
+
+// Regression guard for the MCP-server crash: logger.Error is the single
+// process-exit choke point in the CLI. Loaded in-process by the long-lived
+// MCP server, a process.exit(1) there tears down the whole server and every
+// tool it serves. In server mode Error must THROW (catchable per-request)
+// instead; standalone CLI must keep the process.exit(1) contract.
+describe('logger server-mode hardening', () => {
+  afterEach(() => {
+    setServerMode(false);
+    vi.restoreAllMocks();
+  });
+
+  test('setServerMode toggles the flag', () => {
+    setServerMode(false);
+    expect(isServerMode()).toBe(false);
+    setServerMode(true);
+    expect(isServerMode()).toBe(true);
+    setServerMode(false);
+    expect(isServerMode()).toBe(false);
+  });
+
+  test('server mode: Error({exit:true}) throws and does NOT call process.exit', async () => {
+    setServerMode(true);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit must not be called in server mode');
+    });
+
+    await expect(
+      logger.Error('boom in server mode', { notify: false })
+    ).rejects.toThrow(/boom in server mode/);
+
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  test('CLI mode: Error({exit:true}) still calls process.exit(1)', async () => {
+    setServerMode(false);
+    // Mock exit to a no-op so vitest itself survives; assert it was invoked.
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {});
+
+    const ret = await logger.Error('cli fatal', { notify: false });
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    // After the (mocked) exit, control falls through to `return false`.
+    expect(ret).toBe(false);
+  });
+
+  test('exit:false: Error never throws and never exits, in either mode', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit must not be called for exit:false');
+    });
+
+    setServerMode(true);
+    await expect(
+      logger.Error('soft error', { exit: false, notify: false })
+    ).resolves.toBe(false);
+
+    setServerMode(false);
+    await expect(
+      logger.Error('soft error', { exit: false, notify: false })
+    ).resolves.toBe(false);
+
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+});

--- a/mcp-min/auth.js
+++ b/mcp-min/auth.js
@@ -37,7 +37,7 @@ export async function resolveAuth(params, ctx = {}) {
   // Priority 2: Named .pos environment. When an env name is given we resolve it
   // directly without falling back to MPKIT_* — the caller is being explicit.
   if (params?.env) {
-    const found = await settingsModule.fetchSettings(params.env);
+    const found = await settingsModule.fetchSettings(params.env, { exit: false });
     if (found) return { ...found, source: `.pos(${params.env})` };
     throw new Error(`Environment '${params.env}' not found in .pos config`);
   }

--- a/mcp-min/index.js
+++ b/mcp-min/index.js
@@ -1,6 +1,12 @@
 import startStdio from './stdio-server.js';
 import startHttp from './http-server.js';
 import log from './log.js';
+import { setServerMode } from '../lib/logger.js';
+
+// This host loads CLI code in-process; a fatal logger.Error must throw (caught
+// per-request), never process.exit and take down all tools. Enable before any
+// tool can run.
+setServerMode(true);
 
 const PORT = process.env.MCP_MIN_PORT || 5910;
 

--- a/package.json
+++ b/package.json
@@ -41,9 +41,11 @@
     "pOS"
   ],
   "dependencies": {
+    "@inquirer/prompts": "^8.3.0",
     "@platformos/platformos-check-node": "^0.0.19",
     "@platformos/platformos-common": "^0.0.17",
     "@platformos/platformos-language-server-node": "^0.0.19",
+    "@platformos/platformos-mcp-supervisor": "^0.0.1",
     "is-stream": "^4.0.1",
     "yazl": "^3.3.1",
     "async": "^3.2.6",
@@ -85,6 +87,8 @@
   "preferGlobal": true,
   "bin": {
     "pos-cli": "bin/pos-cli.js",
+    "pos-cli-ai": "bin/pos-cli-ai.js",
+    "pos-cli-ai-init": "bin/pos-cli-ai-init.js",
     "pos-cli-audit": "bin/pos-cli-audit.js",
     "pos-cli-check": "bin/pos-cli-check.js",
     "pos-cli-check-init": "bin/pos-cli-check-init.js",
@@ -105,6 +109,7 @@
     "pos-cli-mcp-config": "bin/pos-cli-mcp-config.js",
     "pos-cli-migrations": "bin/pos-cli-migrations.js",
     "pos-cli-modules": "bin/pos-cli-modules.js",
+    "pos-cli-supervisor": "bin/pos-cli-supervisor.js",
     "pos-cli-sync": "bin/pos-cli-sync.js",
     "pos-cli-test": "bin/pos-cli-test.js",
     "pos-cli-test-run": "bin/pos-cli-test-run.js"

--- a/test/integration/ai.test.js
+++ b/test/integration/ai.test.js
@@ -1,0 +1,59 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import exec from '#test/utils/exec';
+import cliPath from '#test/utils/cliPath';
+
+vi.setConfig({ testTimeout: 60000 });
+
+let tmpDir;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pos-cli-ai-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const run = (options = '') => exec(`${cliPath} ai init ${options}`, { cwd: tmpDir });
+
+describe('pos-cli ai init', () => {
+  test('--tool claude creates .mcp.json with both servers', async () => {
+    const { stdout, code } = await run('--tool claude');
+
+    expect(code).toEqual(0);
+    expect(stdout).toMatch('Registered MCP servers');
+
+    const config = JSON.parse(fs.readFileSync(path.join(tmpDir, '.mcp.json'), 'utf8'));
+    expect(config.mcpServers.platformos.command).toEqual('pos-cli-mcp');
+    expect(config.mcpServers['platformos-supervisor'].command).toEqual('pos-cli-supervisor');
+  });
+
+  test('--tool other prints the snippet and writes nothing', async () => {
+    const { stdout, code } = await run('--tool other');
+
+    expect(code).toEqual(0);
+    expect(stdout).toMatch('pos-cli-supervisor');
+    expect(fs.existsSync(path.join(tmpDir, '.mcp.json'))).toBeFalsy();
+  });
+
+  test('--tool with unknown value fails with allowed choices', async () => {
+    const { stderr, code } = await run('--tool bogus');
+
+    expect(code).not.toEqual(0);
+    expect(stderr).toMatch(/allowed choices/i);
+    expect(stderr).toMatch('claude');
+  });
+
+  test('help lists the ai command and its init subcommand', async () => {
+    const aiHelp = await exec(`${cliPath} ai --help`);
+    expect(aiHelp.stdout).toMatch('Usage: pos-cli ai');
+    expect(aiHelp.stdout).toMatch('init');
+    expect(aiHelp.stdout).toMatch('register platformOS MCP servers');
+
+    const rootHelp = await exec(`${cliPath} --help`);
+    expect(rootHelp.stdout).toMatch('configure AI tools');
+  });
+});

--- a/test/unit/ai.test.js
+++ b/test/unit/ai.test.js
@@ -1,0 +1,107 @@
+import { vi, describe, test, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { withTmpDir } from '#test/utils/withTmpDir.js';
+import logger from '#lib/logger.js';
+import { init } from '#lib/ai.js';
+
+vi.mock('#lib/logger.js', () => ({
+  default: {
+    Error: vi.fn(),
+    Success: vi.fn(),
+    Info: vi.fn(),
+    Warn: vi.fn(),
+    Log: vi.fn(),
+    Debug: vi.fn()
+  }
+}));
+
+const getTmpDir = withTmpDir();
+
+const configPath = (...segments) => path.join(getTmpDir(), ...segments);
+const readJson = (...segments) => JSON.parse(fs.readFileSync(configPath(...segments), 'utf8'));
+
+describe('ai init', () => {
+  test('claude - creates .mcp.json with both servers', async () => {
+    await init({ tool: 'claude', rootPath: getTmpDir() });
+
+    const config = readJson('.mcp.json');
+    expect(config.mcpServers.platformos.command).toEqual('pos-cli-mcp');
+    expect(config.mcpServers['platformos-supervisor'].command).toEqual('pos-cli-supervisor');
+    expect(logger.Success).toHaveBeenCalledWith(expect.stringMatching(/Registered MCP servers/));
+  });
+
+  test('claude - preserves unrelated keys and foreign servers', async () => {
+    fs.writeFileSync(
+      configPath('.mcp.json'),
+      JSON.stringify({
+        someOtherSetting: true,
+        mcpServers: { github: { command: 'github-mcp', args: ['--stdio'] } }
+      })
+    );
+
+    await init({ tool: 'claude', rootPath: getTmpDir() });
+
+    const config = readJson('.mcp.json');
+    expect(config.someOtherSetting).toEqual(true);
+    expect(config.mcpServers.github).toEqual({ command: 'github-mcp', args: ['--stdio'] });
+    expect(config.mcpServers.platformos.command).toEqual('pos-cli-mcp');
+    expect(config.mcpServers['platformos-supervisor'].command).toEqual('pos-cli-supervisor');
+  });
+
+  test('claude - second run is idempotent and does not rewrite the file', async () => {
+    await init({ tool: 'claude', rootPath: getTmpDir() });
+    const firstRunContent = fs.readFileSync(configPath('.mcp.json'), 'utf8');
+
+    await init({ tool: 'claude', rootPath: getTmpDir() });
+
+    expect(fs.readFileSync(configPath('.mcp.json'), 'utf8')).toEqual(firstRunContent);
+    expect(logger.Success).toHaveBeenLastCalledWith(expect.stringMatching(/already configured/));
+  });
+
+  test('claude - overwrites our entries when they differ, reports update', async () => {
+    fs.writeFileSync(
+      configPath('.mcp.json'),
+      JSON.stringify({ mcpServers: { platformos: { command: 'outdated-command' } } })
+    );
+
+    await init({ tool: 'claude', rootPath: getTmpDir() });
+
+    const config = readJson('.mcp.json');
+    expect(config.mcpServers.platformos.command).toEqual('pos-cli-mcp');
+    expect(logger.Info).toHaveBeenCalledWith(expect.stringMatching(/Updated existing entries.*platformos/));
+  });
+
+  test('cursor - creates .cursor/mcp.json', async () => {
+    await init({ tool: 'cursor', rootPath: getTmpDir() });
+
+    const config = readJson('.cursor', 'mcp.json');
+    expect(config.mcpServers.platformos.command).toEqual('pos-cli-mcp');
+    expect(config.mcpServers['platformos-supervisor'].command).toEqual('pos-cli-supervisor');
+  });
+
+  test('vscode - creates .vscode/mcp.json with servers key and stdio type', async () => {
+    await init({ tool: 'vscode', rootPath: getTmpDir() });
+
+    const config = readJson('.vscode', 'mcp.json');
+    expect(config.mcpServers).toBeUndefined();
+    expect(config.servers.platformos).toEqual({ type: 'stdio', command: 'pos-cli-mcp' });
+    expect(config.servers['platformos-supervisor']).toEqual({ type: 'stdio', command: 'pos-cli-supervisor' });
+  });
+
+  test('other - writes no files and prints the snippet', async () => {
+    await init({ tool: 'other', rootPath: getTmpDir() });
+
+    expect(fs.readdirSync(getTmpDir())).toEqual([]);
+    expect(logger.Log).toHaveBeenCalledWith(expect.stringContaining('pos-cli-supervisor'));
+  });
+
+  test('claude - aborts on invalid JSON without touching the file', async () => {
+    fs.writeFileSync(configPath('.mcp.json'), '{ not valid json');
+
+    await init({ tool: 'claude', rootPath: getTmpDir() });
+
+    expect(logger.Error).toHaveBeenCalledWith(expect.stringMatching(/not valid JSON/));
+    expect(fs.readFileSync(configPath('.mcp.json'), 'utf8')).toEqual('{ not valid json');
+  });
+});


### PR DESCRIPTION
## pos-cli-mcp: server-wide crash on any fatal tool error

## Problem
The MCP server runs all its tools in a single process. Any tool that hit a fatal error path resolved through the CLI's logger.Error, which calls process.exit(1). Because the tools aren't isolated subprocesses, that exit terminated the entire server — one recoverable per-tool error took down every tool at once and forced a manual reconnect.

## Why fix
A long-lived server must never be brought down by a single request's error. The failure should be returned to the caller as a normal error response while the server keeps serving all other tools. The server code even had a catchable-error path already written for this case, but it was unreachable because the shared helper exited before it could run.

## What was fixed
Fatal errors under the MCP server now throw instead of exiting, so the server's per-request handler catches them and returns a clean error — and stays alive. Standalone CLI behavior is unchanged (it still exits as before).

How
- Added a server-mode flag; when the MCP server starts it enables it.
- In server mode, logger.Error throws instead of process.exit — this is the single choke point, so it covers every tool, not just one path.
- The environment-resolution helper gained a non-exiting mode (returns instead of exiting) so the server's existing catchable error path is reachable.
- Added unit tests: server mode throws and never exits; CLI mode still exits; the non-exiting path never throws or exits.